### PR TITLE
Use find_zero instead of fzero as the latter is type unstable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,10 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+Aqua = ">= 0.8"
 Roots = "0.8, 1, 2"
 SpecialFunctions = "0.8, 0.9, 0.10, 1, 2"
+Test = ">= 0.0"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -14,8 +14,7 @@ julia = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "JET", "Test"]
+test = ["Aqua", "Test"]

--- a/src/FunctionZeros.jl
+++ b/src/FunctionZeros.jl
@@ -49,7 +49,7 @@ for `n` = `1,2,...`.
 
 `order` is passed to the function `Roots.fzero`.
 """
-besselj_zero(nu, n; order=2) = Roots.fzero((x) -> SpecialFunctions.besselj(nu, x),
+besselj_zero(nu, n; order=2) = Roots.find_zero((x) -> SpecialFunctions.besselj(nu, x),
                                            bessel_zero_asymptotic(nu, n, 1); order=order)
 
 """
@@ -60,7 +60,7 @@ for `n` = `1,2,...`.
 
 `order` is passed to the function `Roots.fzero`.
 """
-bessely_zero(nu, n; order=2) = Roots.fzero((x) -> SpecialFunctions.bessely(nu, x),
+bessely_zero(nu, n; order=2) = Roots.find_zero((x) -> SpecialFunctions.bessely(nu, x),
                                            bessel_zero_asymptotic(nu, n, 2); order=order)
 
 end # module FunctionZeros

--- a/test/aqua_test.jl
+++ b/test/aqua_test.jl
@@ -7,11 +7,6 @@ const PkgName = FunctionZeros
     Aqua.test_deps_compat(PkgName)
 end
 
-# This often gives false positive
-@testset "aqua project toml formatting" begin
-    Aqua.test_project_toml_formatting(PkgName)
-end
-
 @testset "aqua unbound_args" begin
     Aqua.test_unbound_args(PkgName)
 end
@@ -21,12 +16,12 @@ end
 end
 
 # Depending on Optim causes many ambiguity errors outside our control
-# @testset "aqua test ambiguities" begin
-#     Aqua.test_ambiguities([PkgName, Core, Base])
-# end
+@testset "aqua test ambiguities" begin
+    Aqua.test_ambiguities([PkgName, Core, Base])
+end
 
 @testset "aqua piracy" begin
-    Aqua.test_piracy(PkgName)
+    Aqua.test_piracies(PkgName)
 end
 
 @testset "aqua project extras" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,10 @@
 using FunctionZeros
 using Test
 
-if VERSION >= v"1.7"
-    include("jet_test.jl")
-end
+# JET internals changed, and we use them.
+# if VERSION >= v"1.7"
+#     include("jet_test.jl")
+# end
 
 include("aqua_test.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using FunctionZeros
 using Test
 
+# I actually have fixed this in other packages.
+# Could do the same here
 # JET internals changed, and we use them.
 # if VERSION >= v"1.7"
 #     include("jet_test.jl")


### PR DESCRIPTION
* It doesn't seem to be documented, but the fzero method we call is type unstable.
* Disabled JET in test because we used internals of JET and they changed. But we need to filter out spurious fails. So maybe fix later.

Closes #16